### PR TITLE
Maj fichier connexion/inscription/user et userinterface

### DIFF
--- a/connexion.php
+++ b/connexion.php
@@ -51,7 +51,8 @@
 				}
 				// Vérification du mot de passe
 				if (password_verify($mdp, $ar_identification_MDP)) {
-					echo "Vous êtes connecté !";
+					echo "<h1>Vous êtes connecté !</h1>Vous serez redirigé dans 3 secondes";
+					header("refresh:3;url=userinterface.php");
 				} else {
 					echo "Mot de passe invalide";
 					echo "<br/><a href='connexion.html'> << retour à la page de connexion </a>";

--- a/user.php
+++ b/user.php
@@ -13,25 +13,30 @@ class user{
     }
 
 	//getter
-	public function getId(){
-		return $this->id;
-	}
-	public function getNom(){
-		return $this->nom;
-	}
-	public function getPrenom(){
-		return $this->prenom;
-	}
-	public function getPseudo(){
-		return $this->pseudo;
-	}
-	public function getEmail(){
-		return $this->email;
-	}
-	public function getType(){
-		return $this->type;
-	}
+	public function __get($variable){
+			if($variable != "id"): return $this->$variable;
+			endif;
+		}
+	// public function getId(){
+	// 	return $this->id;
+	// }
+	// public function getNom(){
+	// 	return $this->nom;
+	// }
+	// public function getPrenom(){
+	// 	return $this->prenom;
+	// }
+	// public function getPseudo(){
+	// 	return $this->pseudo;
+	// }
+	// public function getEmail(){
+	// 	return $this->email;
+	// }
+	// public function getType(){
+	// 	return $this->type;
+	// }
 	
+
 	//setter
 	public function setNom($newNom){
 		// Vérification de la NULL-ité du nom
@@ -64,30 +69,37 @@ class user{
 	}
 }
 
-// Connection à la BDD
-$user = "root";
-$pass = "";
+include('bdd_connect.php');
+$db = new bddConnect();
 
-try {
-	// Affichage des objets utilisateurs
-	$dbh = new PDO("mysql:dbname=site_jv;host=localhost", $user, $pass);
-	$requeteUtilisateur = $dbh->query('SELECT * from user');
-	$i = 1;
-    foreach($requeteUtilisateur as $row) {
-		$user = new user($row['id'], $row['nom'], $row['prenom'], $row['pseudo'], $row['email'], $row['type']);
-		echo "Utilisateur n°" .$i ."</br>";
-		echo "Id : " .$user->getId() ."</br>";
-		echo "Nom : " .$user->getNom() ."</br>";
-		echo "Prenom : " .$user->getPrenom() ."</br>";
-		echo "Pseudo : " .$user->getPseudo() ."</br>";
-		echo "Email : " .$user->getEmail() ."</br>";
-		echo "Type : " .$user->getType() ."</br>";
-		echo "</br>";
-		$i++;
-	}
-    $dbrequete = null;
-} catch (PDOException $e) {
-	echo 'Echec de la connexion : ' .$e->getMessage();
-}
+$requeteUtilisateur = $db->query('SELECT id, nom, prenom, pseudo, email, type FROM user');
+var_dump("<pre>", $requeteUtilisateur, "</pre>");
+
+
+// // Connection à la BDD
+// $user = "root";
+// $pass = "";
+
+// try {
+// 	// Affichage des objets utilisateurs
+// 	$dbh = new PDO("mysql:dbname=site_jv;host=localhost", $user, $pass);
+// 	$requeteUtilisateur = $dbh->query('SELECT * from user');
+// 	$i = 1;
+//     foreach($requeteUtilisateur as $row) {
+// 		$user = new user($row['id'], $row['nom'], $row['prenom'], $row['pseudo'], $row['email'], $row['type']);
+// 		echo "Utilisateur n°" .$i ."</br>";
+// 		echo "Id : " .$user->getId() ."</br>";
+// 		echo "Nom : " .$user->getNom() ."</br>";
+// 		echo "Prenom : " .$user->getPrenom() ."</br>";
+// 		echo "Pseudo : " .$user->getPseudo() ."</br>";
+// 		echo "Email : " .$user->getEmail() ."</br>";
+// 		echo "Type : " .$user->getType() ."</br>";
+// 		echo "</br>";
+// 		$i++;
+// 	}
+//     $dbrequete = null;
+// } catch (PDOException $e) {
+// 	echo 'Echec de la connexion : ' .$e->getMessage();
+// }
 
 ?>

--- a/userinterface.php
+++ b/userinterface.php
@@ -1,0 +1,22 @@
+<?php
+	// Connection à la BDD
+	include('bdd_connect.php');
+	$db = new bddConnect();
+?>
+<!DOCTYPE html>
+<html lang="fr">
+	<head>
+		<meta charset="utf-8">
+		<title>Utilisateur</title>
+	</head>
+	<body>
+		<header>
+			<h1>Pseudo utilisateur :
+				<?php 
+					$requeteUtilisateur = $db->query("SELECT * FROM user WHERE nom='toto'");
+					echo $requeteUtilisateur[0]->pseudo ."</h1></br>";
+					echo "<h2>Prénom : " .$requeteUtilisateur[0]->prenom ."</h2>";
+					?>
+		</header>
+	</body>
+</html>


### PR DESCRIPTION
connexion => redirection vers la page userinterface (page type "profil")
inscription => vérification plus poussée : pas de doublon d'email ni de pseudo + les champs pseudo, nom, prenom et email ne peuvent plus contenir que des espaces
userinterface => page type "profil", à améliorer pour que l'user logué tombe sur sa page grâçe aux session (l.16 "WHERE" => type WHERE nomSession = pseudo).